### PR TITLE
feat: move agent_dir config to test spec agent.build_context

### DIFF
--- a/.github/workflows/selftest.yml
+++ b/.github/workflows/selftest.yml
@@ -46,7 +46,6 @@ jobs:
           account_id: ${{ secrets.ACCOUNT_ID }}
           api_key: ${{ secrets.API_KEY }}
           license_key: ${{ secrets.LICENSE_KEY }}
-          agent_dir: newrelic-integration-e2e/test/testdata/kafka/agent_dir
   test_local_k8s:
     runs-on: ubuntu-latest
     name: Test run the e2e test on k8s local testdata

--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,6 @@ VERBOSE ?= false
 RETRY_ATTEMPTS ?= 10
 RETRY_SECONDS ?= 30
 
-ifneq ($(strip $(AGENT_DIR)),)
-    AGENT_DIR_COMPOSED = $(ROOT_DIR)/$(AGENT_DIR)
-endif
-
 all: validate test snyk-test
 
 validate:
@@ -31,6 +27,13 @@ snyk-test:
 run:
 	@printf "=== newrelic-integration-e2e === [ run / $* ]: running the binary \n"
 	@cd newrelic-integration-e2e; go run $(CURDIR)/newrelic-integration-e2e/cmd/main.go \
-	 --commit_sha=$(COMMIT_SHA) --retry_attempts=$(RETRY_ATTEMPTS) --retry_seconds=$(RETRY_SECONDS) \
-	 --agent_dir=$(AGENT_DIR_COMPOSED) --account_id=$(ACCOUNT_ID) --api_key=$(API_KEY) --license_key=$(LICENSE_KEY) \
-	 --spec_path=$(ROOT_DIR)/$(SPEC_PATH) --verbose_mode=$(VERBOSE) --agent_enabled=$(AGENT_ENABLED) --region=$(REGION)
+	 --commit_sha=$(COMMIT_SHA) \
+	 --retry_attempts=$(RETRY_ATTEMPTS) \
+	 --retry_seconds=$(RETRY_SECONDS) \
+	 --account_id=$(ACCOUNT_ID) \
+	 --api_key=$(API_KEY) \
+	 --license_key=$(LICENSE_KEY) \
+	 --spec_path=$(ROOT_DIR)/$(SPEC_PATH) \
+	 --verbose_mode=$(VERBOSE) \
+	 --agent_enabled=$(AGENT_ENABLED) \
+	 --region=$(REGION)

--- a/README.md
+++ b/README.md
@@ -162,6 +162,8 @@ A [docker-compose.yml](newrelic-integration-e2e/internal/agent/resources/docker-
 
 If a custom image is needed, `agent.build_context` must contain a relative path to a directory containing a `docker-compose.yml`.In order to mount the binaries to the image `E2E_EXPORTER_BIN`, `E2E_NRI_CONFIG` and `E2E_NRI_BIN` will be set as env variables with the path to the temporary folders where assets are copied.
 
+A concrete example can be checked in [this test](newrelic-integration-e2e/test/testdata/kafka/kafka-e2e.yml).
+
 ## Types of test
 All the queries done to NROne are done with an extra WHERE condition that is `WHERE testKey = 'COMMMITSHA + 10 Digit alphanumeric'` a custom attribute added to the agent. This attribute is decorated in all the emitted metrics. 
 

--- a/README.md
+++ b/README.md
@@ -17,13 +17,12 @@ New Relic has two kinds of integrations:
 
 - It reads the e2e test descriptor file/s that must be passed as an argument to the action.
 - For each scenario present in the descriptor:  
-    - It installs the infrastructure agent & the required packages.
-    - It launches services dependencies (e.g. a docker-compose ) if specified in the before step.
-    - It verifies that the required services are up & running
+    - It launches services dependencies (e.g. a docker-compose ) if specified in the `before` step.
     - It creates a config file with the details in the descriptor. 
     - Adds a custom-attribute to the config:
         - Composed by the current commit sha + a new 10 alphanumeric-random digit on each scenario.
         - The tests will look for this label to fetch the metrics and the entities from the New Relic backend.
+    - It launches the default docker-compose of the Infra Agent mounting the binaries and configs so the integrations are run automatically.
     - The runner executes the tests one by one, checking that metrics &/or entities are being created correctly. 
     - If the test fails, it's retried after the `retry_seconds` (default 30s) and up to the `retry_attempts` (default 10) defined for the action. 
     - It stops & removes the services if specified in the after step.
@@ -60,7 +59,6 @@ jobs:
           account_id: ${{ secrets.ACCOUNT_ID }}
           api_key: ${{ secrets.API_KEY }}
           license_key: ${{ secrets.LICENSE_KEY }}
-          agent_dir: exporters/powerdns/e2e/agent_dir
           retry_seconds: 30
           retry_attempts: 10
           verbose: false
@@ -73,7 +71,6 @@ The required fields are:
 - `license_key` required by the agent.
 
 Optional parameters:
-- `agent_dir` path to a custom agent_dir in a specific e2e with a docker-compose and Dockerfile in it. If not set a default compose will be used.
 - `retry_seconds` it's the number of seconds to wait after retrying a test. default: 30.
 - `retry_attempts` it's the number of attempts a failed test can be retried. default: 10.
 - `verbose` if set to to true the agent logs and other useful debug logs will be printed. default: false.
@@ -90,6 +87,7 @@ The spec file for the e2e needs to be a yaml file with the following structure:
 `custom_test_key`: (Optional) Key of the custom attribute to test. Useful in case you cannot control the keyName. 
 
 `agent`: Extra environment variables and/or integrations required for the e2e.
+- `build_context` : Relative path to the directory where a custom `docker-compose.yml` will be build and run to launch the Agent. If not specified a default embedded docker-compose is executed. 
 - `integrations` : Additional integrations needed for the e2e.
 - `env_vars` : Additional EnvVars for the agent execution.
 
@@ -119,8 +117,6 @@ description: |
   End-to-end tests for PowerDNS integration
   
 agent:
-  integrations:
-    nri-prometheus:  bin/nri-prometheus # nri-prometheus is added with the agent by default, but we added here as an example
   env_vars:
     NRJMX_VERSION: "1.5.3"
 
@@ -159,6 +155,12 @@ scenarios:
             - powerdns_recursor_cache_lookups_total
           # additionals: ""
 ```
+
+### Custom Agent image
+
+A [docker-compose.yml](newrelic-integration-e2e/internal/agent/resources/docker-compose.yml) is embedded into the code which is used by default to build the Agent image that contains the integrations and configs to be tested. 
+
+If a custom image is needed, `agent.build_context` must contain a relative path to a directory containing a `docker-compose.yml`.In order to mount the binaries to the image `E2E_EXPORTER_BIN`, `E2E_NRI_CONFIG` and `E2E_NRI_BIN` will be set as env variables with the path to the temporary folders where assets are copied.
 
 ## Types of test
 All the queries done to NROne are done with an extra WHERE condition that is `WHERE testKey = 'COMMMITSHA + 10 Digit alphanumeric'` a custom attribute added to the agent. This attribute is decorated in all the emitted metrics. 

--- a/action.yml
+++ b/action.yml
@@ -21,9 +21,6 @@ inputs:
     description: Number of attempts a failed test can be retried
     required: false
     default: "10"
-  agent_dir:
-    description: Custom agent dir
-    required: false
   agent_enabled:
     description: Enable the agent execution
     required: false
@@ -48,5 +45,5 @@ runs:
   using: "composite"
   steps:
     - id: run-spec
-      run: make -C ${{ github.action_path }} COMMIT_SHA=${{ github.sha }} AGENT_ENABLED=${{ inputs.agent_enabled }} ROOT_DIR=${{ github.workspace }} AGENT_DIR=${{ inputs.agent_dir }} ACCOUNT_ID=${{ inputs.account_id }} API_KEY=${{ inputs.api_key }} LICENSE_KEY=${{ inputs.license_key }} SPEC_PATH=${{ inputs.spec_path }} RETRY_ATTEMPTS=${{ inputs.retry_attempts }} RETRY_SECONDS=${{ inputs.retry_seconds }} VERBOSE=${{ inputs.verbose }} REGION=${{ inputs.region }} run
+      run: make -C ${{ github.action_path }} COMMIT_SHA=${{ github.sha }} AGENT_ENABLED=${{ inputs.agent_enabled }} ROOT_DIR=${{ github.workspace }} ACCOUNT_ID=${{ inputs.account_id }} API_KEY=${{ inputs.api_key }} LICENSE_KEY=${{ inputs.license_key }} SPEC_PATH=${{ inputs.spec_path }} RETRY_ATTEMPTS=${{ inputs.retry_attempts }} RETRY_SECONDS=${{ inputs.retry_seconds }} VERBOSE=${{ inputs.verbose }} REGION=${{ inputs.region }} run
       shell: bash

--- a/newrelic-integration-e2e/cmd/main.go
+++ b/newrelic-integration-e2e/cmd/main.go
@@ -17,7 +17,6 @@ const (
 	flagApiKey        = "api_key"
 	flagAccountID     = "account_id"
 	flagLicenseKey    = "license_key"
-	flagAgentDir      = "agent_dir"
 	flagAgentEnabled  = "agent_enabled"
 	flagRetryAttempts = "retry_attempts"
 	flagRetrySecons   = "retry_seconds"
@@ -25,10 +24,9 @@ const (
 	flagRegion        = "region"
 )
 
-func processCliArgs() (string, string, string, bool, string, int, int, int, string, logrus.Level, string) {
+func processCliArgs() (string, string, bool, string, int, int, int, string, logrus.Level, string) {
 	specsPath := flag.String(flagSpecPath, "", "Path to the spec file")
 	licenseKey := flag.String(flagLicenseKey, "", "New Relic License Key")
-	agentDir := flag.String(flagAgentDir, "", "Directory used to deploy the agent")
 	agentEnabled := flag.Bool(flagAgentEnabled, true, "If false the agent is not run")
 	verboseMode := flag.Bool(flagVerboseMode, false, "If true the debug level is enabled")
 	apiKey := flag.String(flagApiKey, "", "New Relic Api Key")
@@ -56,20 +54,18 @@ func processCliArgs() (string, string, string, bool, string, int, int, int, stri
 	if *verboseMode {
 		logLevel = logrus.DebugLevel
 	}
-	return *licenseKey, *specsPath, *agentDir, *agentEnabled, *apiKey, *accountID, *retryAttempts, *retrySeconds, *commitSha, logLevel, *region
-
+	return *licenseKey, *specsPath, *agentEnabled, *apiKey, *accountID, *retryAttempts, *retrySeconds, *commitSha, logLevel, *region
 }
 
 func main() {
 	logrus.Info("running e2e")
 
-	licenseKey, specsPath, agentDir, agentEnabled, apiKey, accountID, retryAttempts, retrySeconds, commitSha, logLevel, region := processCliArgs()
+	licenseKey, specsPath, agentEnabled, apiKey, accountID, retryAttempts, retrySeconds, commitSha, logLevel, region := processCliArgs()
 	s, err := e2e.NewSettings(
 		e2e.SettingsWithSpecPath(specsPath),
 		e2e.SettingsWithLogLevel(logLevel),
 		e2e.SettingsWithLicenseKey(licenseKey),
 		e2e.SettingsWithAgentEnabled(agentEnabled),
-		e2e.SettingsWithAgentDir(agentDir),
 		e2e.SettingsWithApiKey(apiKey),
 		e2e.SettingsWithAccountID(accountID),
 		e2e.SettingsWithRetryAttempts(retryAttempts),

--- a/newrelic-integration-e2e/internal/agent/agent.go
+++ b/newrelic-integration-e2e/internal/agent/agent.go
@@ -16,11 +16,11 @@ import (
 )
 
 const (
-	integrationsCfgDir    = "integrations.d"
+	IntegrationsCfgDir    = "integrations.d"
 	integrationsCfgDirEnv = "E2E_NRI_CONFIG"
-	exportersDir          = "exporters"
+	ExportersDir          = "exporters"
 	exportersDirEnv       = "E2E_EXPORTER_BIN"
-	integrationsBinDir    = "bin"
+	IntegrationsBinDir    = "bin"
 	integrationsBinDirEnv = "E2E_NRI_BIN"
 	dockerCompose         = "docker-compose.yml"
 	defConfigFile         = "nri-config.yml"
@@ -38,7 +38,7 @@ type Agent interface {
 
 type agent struct {
 	scenario          spec.Scenario
-	agentDir          string
+	agentBuildContext string
 	configsDir        string
 	containerName     string
 	exportersDir      string
@@ -53,13 +53,13 @@ type agent struct {
 }
 
 func NewAgent(settings e2e.Settings) *agent {
-	agentDir := settings.AgentDir()
+	agentBuildContext := settings.AgentBuildContext()
 
 	a := agent{
 		specParentDir:     settings.SpecParentDir(),
 		containerName:     container,
-		agentDir:          agentDir,
-		dockerComposePath: filepath.Join(agentDir, dockerCompose),
+		agentBuildContext: agentBuildContext,
+		dockerComposePath: filepath.Join(agentBuildContext, dockerCompose),
 		licenseKey:        settings.LicenseKey(),
 		logger:            settings.Logger(),
 		customTagKey:      settings.SpecDefinition().CustomTestKey,
@@ -74,7 +74,7 @@ func NewAgent(settings e2e.Settings) *agent {
 }
 
 func (a *agent) initDefaultCompose() error {
-	if a.agentDir != "" {
+	if a.agentBuildContext != "" {
 		return nil
 	}
 
@@ -100,7 +100,7 @@ func (a *agent) initDefaultCompose() error {
 }
 
 func (a *agent) initialize() error {
-	configDir, err := ioutil.TempDir(a.agentDir, integrationsCfgDir)
+	configDir, err := ioutil.TempDir(a.agentBuildContext, IntegrationsCfgDir)
 	if err != nil {
 		return fmt.Errorf("creating configs dir: %w", err)
 	}
@@ -108,7 +108,7 @@ func (a *agent) initialize() error {
 	a.logger.Debugf("configs dir: %s", configDir)
 	a.configsDir = configDir
 
-	exportersDir, err := ioutil.TempDir(a.agentDir, exportersDir)
+	exportersDir, err := ioutil.TempDir(a.agentBuildContext, ExportersDir)
 	if err != nil {
 		return fmt.Errorf("creating exporters dir: %w", err)
 	}
@@ -116,7 +116,7 @@ func (a *agent) initialize() error {
 	a.logger.Debugf("exporters dir: %s", exportersDir)
 	a.exportersDir = exportersDir
 
-	binsDir, err := ioutil.TempDir(a.agentDir, integrationsBinDir)
+	binsDir, err := ioutil.TempDir(a.agentBuildContext, IntegrationsBinDir)
 	if err != nil {
 		return fmt.Errorf("creating integration bin dir: %w", err)
 	}
@@ -233,7 +233,7 @@ func (a *agent) Stop() error {
 	}
 
 	// Remove compose file when using default.
-	if a.agentDir == "" {
+	if a.agentBuildContext == "" {
 		if err := os.RemoveAll(a.dockerComposePath); err != nil {
 			return err
 		}

--- a/newrelic-integration-e2e/internal/agent/agent.go
+++ b/newrelic-integration-e2e/internal/agent/agent.go
@@ -37,7 +37,6 @@ type Agent interface {
 }
 
 type agent struct {
-	scenario          spec.Scenario
 	agentBuildContext string
 	configsDir        string
 	containerName     string
@@ -161,7 +160,6 @@ func (a *agent) addIntegrationsConfigFile(integrations []spec.Integration) error
 // SetUp creates temporary folders where it copies the binaries and
 // config files that are going to be mounted the agent.
 func (a *agent) SetUp(scenario spec.Scenario) error {
-	a.scenario = scenario
 	if err := a.initDefaultCompose(); err != nil {
 		return err
 	}

--- a/newrelic-integration-e2e/internal/agent/testdata/spec_file.yml
+++ b/newrelic-integration-e2e/internal/agent/testdata/spec_file.yml
@@ -2,6 +2,7 @@ description: |
   End-to-end tests for PowerDNS integration
 
 agent:
+  build_context: build_context_dir
   integrations:
     nri-prometheus:  nri-prometheus
 

--- a/newrelic-integration-e2e/internal/settings.go
+++ b/newrelic-integration-e2e/internal/settings.go
@@ -17,7 +17,6 @@ type settingOptions struct {
 	specPath      string
 	specParentDir string
 	licenseKey    string
-	agentDir      string
 	agentEnabled  bool
 	accountID     int
 	apiKey        string
@@ -45,12 +44,6 @@ func SettingsWithLogLevel(logLevel logrus.Level) SettingOption {
 func SettingsWithLicenseKey(licenseKey string) SettingOption {
 	return func(o *settingOptions) {
 		o.licenseKey = licenseKey
-	}
-}
-
-func SettingsWithAgentDir(agentDir string) SettingOption {
-	return func(o *settingOptions) {
-		o.agentDir = agentDir
 	}
 }
 
@@ -100,7 +93,7 @@ type Settings interface {
 	Logger() *logrus.Logger
 	SpecDefinition() *spec.Definition
 	AgentEnabled() bool
-	AgentDir() string
+	AgentBuildContext() string
 	SpecParentDir() string
 	LicenseKey() string
 	ApiKey() string
@@ -116,7 +109,6 @@ type settings struct {
 	specDefinition *spec.Definition
 	agentEnabled   bool
 	specParentDir  string
-	agentDir       string
 	licenseKey     string
 	accountID      int
 	apiKey         string
@@ -138,8 +130,12 @@ func (s *settings) SpecDefinition() *spec.Definition {
 	return s.specDefinition
 }
 
-func (s *settings) AgentDir() string {
-	return s.agentDir
+func (s *settings) AgentBuildContext() string {
+	if s.specDefinition == nil || s.specDefinition.AgentExtensions == nil {
+		return ""
+	}
+
+	return filepath.Join(s.specParentDir, s.specDefinition.AgentExtensions.BuildContext)
 }
 
 func (s *settings) AgentEnabled() bool {
@@ -200,7 +196,6 @@ func NewSettings(
 	return &settings{
 		logger:         logger,
 		specDefinition: s,
-		agentDir:       options.agentDir,
 		agentEnabled:   options.agentEnabled,
 		specParentDir:  options.specParentDir,
 		licenseKey:     options.licenseKey,

--- a/newrelic-integration-e2e/internal/spec/definition.go
+++ b/newrelic-integration-e2e/internal/spec/definition.go
@@ -12,6 +12,7 @@ type Definition struct {
 }
 
 type Agent struct {
+	BuildContext string            `yaml:"build_context"`
 	Integrations map[string]string `yaml:"integrations"`
 	EnvVars      map[string]string `yaml:"env_vars"`
 }

--- a/newrelic-integration-e2e/internal/spec/definition_test.go
+++ b/newrelic-integration-e2e/internal/spec/definition_test.go
@@ -7,11 +7,12 @@ import (
 )
 
 func Test_ParseDefinitionFile(t *testing.T) {
-	var sample = `
+	sample := `
 description: |
   End-to-end tests for PowerDNS integration
 
 agent:
+  build_context: /path/to/compose/dir
   integrations:
     nri-prometheus:  bin/nri-prometheus
   env_vars:
@@ -45,6 +46,7 @@ scenarios:
 	assert.Equal(t, "End-to-end tests for PowerDNS integration\n", spec.Description)
 
 	expectedAgentExtensions := Agent{
+		BuildContext: "/path/to/compose/dir",
 		Integrations: map[string]string{
 			"nri-prometheus": "bin/nri-prometheus",
 		},

--- a/newrelic-integration-e2e/test/testdata/kafka/kafka-e2e.yml
+++ b/newrelic-integration-e2e/test/testdata/kafka/kafka-e2e.yml
@@ -2,6 +2,7 @@ description: |
   End-to-end tests for Kafka integration
 
 agent:
+  build_context: ./agent_dir
   env_vars:
     NRJMX_VERSION: "1.5.3"
 

--- a/newrelic-integration-e2e/test/testdata/powerdns/powerdns-e2e.yml
+++ b/newrelic-integration-e2e/test/testdata/powerdns/powerdns-e2e.yml
@@ -1,7 +1,6 @@
 description: |
   End-to-end tests for PowerDNS integration
 
-
 scenarios:
   - description: |
       This scenario will verify that metrics from both PDNS authoritative & PDNS recursor


### PR DESCRIPTION
This PR removes the `agent_dir` parameter from the action and introduce it into the e2e specs as 
```
agent:
  build_context: ./path/to/docker-compose.yml
```
The goal is simplify the action configuration when a custom agent container is needed. 

**Breaking**:
Currently there is no integration using agent dir so I don't expect any impact with this change