### PR TITLE
add mode to output grouped logs using GHA syntax

### DIFF
--- a/newrelic-integration-e2e/internal/newrelic/client.go
+++ b/newrelic-integration-e2e/internal/newrelic/client.go
@@ -56,8 +56,8 @@ func (nrc *nrClient) FindEntityGUIDs(sample, metricName, customTagKey, entityTag
 		return nil, ErrNoResult
 	}
 
-	if len(a.Results[0]["uniques.entity.guid"].([]interface{})) < expectedNumber {
-		return nil, fmt.Errorf("%w: %s", ErrResultNumber, query)
+	if results := len(a.Results[0]["uniques.entity.guid"].([]interface{})); results < expectedNumber {
+		return nil, fmt.Errorf("%w: %s: got %d, expected %d", ErrResultNumber, query, results, expectedNumber)
 	}
 
 	for _, g := range a.Results[0]["uniques.entity.guid"].([]interface{}) {

--- a/newrelic-integration-e2e/internal/runtime/logger/logger.go
+++ b/newrelic-integration-e2e/internal/runtime/logger/logger.go
@@ -1,0 +1,59 @@
+package logger
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/sirupsen/logrus"
+)
+
+// CommandLogger is an object to log output from commands
+type CommandLogger interface {
+	// Open returns an io.Writer the command should write its stdout and stderr to.
+	// Implementations may assume callers do not interact with the underlying writers between calls to Open and Close.
+	Open(name string) io.Writer
+	// Close signals implementations that no more data will be written.
+	// Implementations may write additional trailers when Close is called.
+	Close()
+}
+
+// LogrusLogger is an implementation of CommandLogger that uses a logrus logger.
+type LogrusLogger struct {
+	logrus *logrus.Logger
+	pipe   *io.PipeWriter
+}
+
+func NewLogrusLogger(logger *logrus.Logger) LogrusLogger {
+	return LogrusLogger{logrus: logger}
+}
+
+func (ll LogrusLogger) Open(name string) io.Writer {
+	ll.pipe = ll.logrus.WithField("command", name).Writer()
+	return ll.pipe
+}
+
+func (ll LogrusLogger) Close() {
+	if ll.pipe != nil {
+		_ = ll.pipe.Close()
+	}
+}
+
+// GHALogger implements CommandLogger on top of an io.Writer.
+// GHALogger will wrap command output in groups using the GHA syntax:
+// https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#grouping-log-lines
+type GHALogger struct {
+	io.Writer
+}
+
+func NewGHALogger(writer io.Writer) GHALogger {
+	return GHALogger{writer}
+}
+
+func (gha GHALogger) Open(name string) io.Writer {
+	_, _ = fmt.Fprintf(gha, "::group::%s\n", name)
+	return gha
+}
+
+func (gha GHALogger) Close() {
+	_, _ = fmt.Fprintln(gha, "::endgroup::")
+}

--- a/newrelic-integration-e2e/internal/runtime/runner.go
+++ b/newrelic-integration-e2e/internal/runtime/runner.go
@@ -106,6 +106,7 @@ func (r *Runner) Run() error {
 }
 
 func (r *Runner) executeOSCommands(statements []string, scenarioTag string) error {
+	// Create a logger for the executed commands.
 	var cmdLogger logger.CommandLogger
 	if r.spec.PlainLogs {
 		cmdLogger = logger.NewLogrusLogger(r.logger)
@@ -120,6 +121,7 @@ func (r *Runner) executeOSCommands(statements []string, scenarioTag string) erro
 		cmd.Env = os.Environ()
 		cmd.Env = append(cmd.Env, "SCENARIO_TAG="+scenarioTag)
 
+		// Open a log group for the command and run it.
 		loggerWriter := cmdLogger.Open(stmt)
 		cmd.Stdout = loggerWriter
 		cmd.Stderr = loggerWriter

--- a/newrelic-integration-e2e/internal/runtime/runner.go
+++ b/newrelic-integration-e2e/internal/runtime/runner.go
@@ -1,6 +1,7 @@
 package runtime
 
 import (
+	"fmt"
 	"math/rand"
 	"os"
 	"os/exec"
@@ -112,7 +113,16 @@ func (r *Runner) executeOSCommands(statements []string, scenarioTag string) erro
 		cmd.Env = os.Environ()
 		cmd.Env = append(cmd.Env, "SCENARIO_TAG="+scenarioTag)
 		combinedOutput, err := cmd.CombinedOutput()
-		r.logger.WithField("command", stmt).Info(combinedOutput)
+
+		if r.spec.PlainLogs {
+			r.logger.WithField("command", stmt).Info(combinedOutput)
+		} else {
+			logWriter := r.logger.Writer()
+			_, _ = fmt.Fprintf(logWriter, "::group::%s\n", stmt)
+			_, _ = fmt.Fprint(logWriter, combinedOutput)
+			_, _ = fmt.Fprintln(logWriter, "::endgroup::")
+		}
+
 		if err != nil {
 			return err
 		}

--- a/newrelic-integration-e2e/internal/runtime/runner.go
+++ b/newrelic-integration-e2e/internal/runtime/runner.go
@@ -112,7 +112,7 @@ func (r *Runner) executeOSCommands(statements []string, scenarioTag string) erro
 		cmd.Env = os.Environ()
 		cmd.Env = append(cmd.Env, "SCENARIO_TAG="+scenarioTag)
 		combinedOutput, err := cmd.CombinedOutput()
-		r.logger.Debugf("stdout: %q", combinedOutput)
+		r.logger.WithField("command", stmt).Info(combinedOutput)
 		if err != nil {
 			return err
 		}

--- a/newrelic-integration-e2e/internal/spec/definition.go
+++ b/newrelic-integration-e2e/internal/spec/definition.go
@@ -8,6 +8,7 @@ type Definition struct {
 	Description     string     `yaml:"description"`
 	Scenarios       []Scenario `yaml:"scenarios"`
 	AgentExtensions *Agent     `yaml:"agent"`
+	PlainLogs       bool       `yaml:"plain_logs"`
 	CustomTestKey   string     `yaml:"custom_test_key"`
 }
 


### PR DESCRIPTION
This PR uses the [group log](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#grouping-log-lines) GHA commands to wrap the output of `before` and `after` commands under a nice collapser when running in GHA. Moreover, newlines and special characters are no longer escaped.

A new entry in the test spec, `plain_logs`, have been added to *opt-out* of this behavior.