### PR TITLE
NEWRELIC-3911 make the action to run on docker compose v2

### DIFF
--- a/newrelic-integration-e2e/pkg/dockercompose/docker.go
+++ b/newrelic-integration-e2e/pkg/dockercompose/docker.go
@@ -21,6 +21,7 @@ func Run(path string, container string, envVars map[string]string) error {
 	}
 	args = append(args, "-d", container)
 	cmd := exec.Command(dockerComposeBin, args...)
+	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()


### PR DESCRIPTION
This PR fixes the error `the input device is not a TTY` when running the action locally with docker compose v2 by adding `cmd.Stdin = os.Stdin`.

Note that for now github action is using v1 and because of this we haven't faced this error.