### PR TITLE
feat(nrqls): support missing metrics tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,8 +115,10 @@ The spec file for the e2e needs to be a yaml file with the following structure:
   - `exporter_binary_path` : Relative path to the prometheus exporter if it's needed (Prometheus based integrations)
   - `config` : The config values for this NR integration that will be red by the agent to execute the integration.
 - `tests` : The 3 kinds of tests that will be done to the New relic api to check for metrics/entities in NROne:
-  - `nrqls` : Array of queries that will be executed independently and will fail if returned value is nil. 
-  - `metrics` : Array of metrics to chek existing in NROne
+  - `nrqls` : Array of queries that will be executed independently. You can specify if running a query an error is expected or not. 
+   - `query` : the query to run
+   - `error_expected`: false by default, useful if we want to test that a metric is not being sent 
+  - `metrics` : Array of metrics to check existing in NROne
     - `source` : Relative path to the integration spec file (It defines the entities and metrics) that will be parsed to match the metrics got from NROne.
     - `except_entities` : Array of entities whose metrics will be skipped.
     - `except_metrics` : Array of metrics to skip.
@@ -154,6 +156,7 @@ scenarios:
     tests:
       nrqls:
         - query: "SELECT average(powerdns_authoritative_queries_total) FROM Metric"
+          error_expected: false
       entities:
         - type: "POWERDNS_AUTHORITATIVE"
           data_type: "Metric"

--- a/internal/runtime/nrql_tester.go
+++ b/internal/runtime/nrql_tester.go
@@ -24,8 +24,12 @@ func (nt NRQLTester) Test(tests spec.Tests, customTagKey, customTagValue string)
 	var errors []error
 	for _, nrql := range tests.NRQLs {
 		err := nt.nrClient.NRQLQuery(nrql.Query, customTagKey, customTagValue)
-		if err != nil {
+		if err != nil && !nrql.ErrorExpected {
 			errors = append(errors, fmt.Errorf("querying: %w", err))
+			continue
+		}
+		if err == nil && nrql.ErrorExpected {
+			errors = append(errors, fmt.Errorf("querying running %q: an error was expected", nrql.Query))
 			continue
 		}
 	}

--- a/internal/runtime/nrql_tester.go
+++ b/internal/runtime/nrql_tester.go
@@ -29,7 +29,7 @@ func (nt NRQLTester) Test(tests spec.Tests, customTagKey, customTagValue string)
 			continue
 		}
 		if err == nil && nrql.ErrorExpected {
-			errors = append(errors, fmt.Errorf("querying running %q: an error was expected", nrql.Query))
+			errors = append(errors, fmt.Errorf("an error was expected running: %q", nrql.Query))
 			continue
 		}
 	}

--- a/internal/runtime/nrql_tester.go
+++ b/internal/runtime/nrql_tester.go
@@ -1,6 +1,7 @@
 package runtime
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/newrelic/newrelic-integration-e2e-action/internal/newrelic"
@@ -20,6 +21,8 @@ func NewNRQLTester(nrClient newrelic.Client, logger *logrus.Logger) NRQLTester {
 	}
 }
 
+var ErrorExpected = errors.New("an error was expected")
+
 func (nt NRQLTester) Test(tests spec.Tests, customTagKey, customTagValue string) []error {
 	var errors []error
 	for _, nrql := range tests.NRQLs {
@@ -29,7 +32,7 @@ func (nt NRQLTester) Test(tests spec.Tests, customTagKey, customTagValue string)
 			continue
 		}
 		if err == nil && nrql.ErrorExpected {
-			errors = append(errors, fmt.Errorf("an error was expected running: %q", nrql.Query))
+			errors = append(errors, fmt.Errorf("running %q: %w", nrql.Query, ErrorExpected))
 			continue
 		}
 	}

--- a/internal/runtime/nrql_tester_test.go
+++ b/internal/runtime/nrql_tester_test.go
@@ -22,3 +22,26 @@ func TestNRQLTester_Test(t *testing.T) {
 	errors := nrqlTester.Test(inputTests, "", "")
 	assert.Equal(t, 1, len(errors))
 }
+
+func TestNRQLTester_Test_error(t *testing.T) {
+	log := logrus.New()
+	log.SetOutput(ioutil.Discard)
+	nrqlTester := NewNRQLTester(clientMock{}, log)
+
+	inputTests := spec.Tests{NRQLs: []spec.TestNRQL{
+		{Query: errNRQLQuery, ErrorExpected: true},
+		{Query: "a-correct-query"},
+	}}
+
+	errors := nrqlTester.Test(inputTests, "", "")
+	assert.Equal(t, 0, len(errors))
+
+	inputTests = spec.Tests{NRQLs: []spec.TestNRQL{
+		{Query: errNRQLQuery},
+		{Query: "a-correct-query", ErrorExpected: true},
+	}}
+
+	errors = nrqlTester.Test(inputTests, "", "")
+	assert.Equal(t, 2, len(errors))
+
+}

--- a/internal/runtime/nrql_tester_test.go
+++ b/internal/runtime/nrql_tester_test.go
@@ -43,5 +43,4 @@ func TestNRQLTester_Test_error(t *testing.T) {
 
 	errors = nrqlTester.Test(inputTests, "", "")
 	assert.Equal(t, 2, len(errors))
-
 }

--- a/internal/spec/definition.go
+++ b/internal/spec/definition.go
@@ -41,7 +41,8 @@ type Tests struct {
 }
 
 type TestNRQL struct {
-	Query string `yaml:"query"`
+	Query         string `yaml:"query"`
+	ErrorExpected bool   `yaml:"error_expected"`
 }
 
 type TestEntity struct {


### PR DESCRIPTION
Being able to mark a nrql as expected to fail we can run many tests about metrics expected to be missing