### PR TITLE
Open scenario tag to customers

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Optional parameters:
 - `verbose` if set to to true the agent logs and other useful debug logs will be printed. default: false.
 - `agent_enabled` if set to false then the agent will not be spawned and its lifecycle will be up to the user of the action. Useful when testing K8s like integrations
 - `region` is where to send the e2e data. Possible values: "US", "EU", "Staging", "Local". See `action.yaml` for more info.
-- `scenario_tag` is used as an environment variable in the spec file under `spec_path`. For now, our nri-kubernetes repo uses it as namespace and cluster names. Customers can define this value as their cluster name if they do not want to use random cluster name during the testing.
+- `scenario_tag` is used as an environment variable in the spec file under `spec_path`. By default, the value of this variable is randomly generated. For now, our nri-kubernetes repo uses its random value as Kubernetes cluster and namespace names during the testing. Through this parameter, customers can set its value as their cluster name if they do not want to use random cluster name during the testing.
 
 ## Spec file for the e2e
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Optional parameters:
 - `verbose` if set to to true the agent logs and other useful debug logs will be printed. default: false.
 - `agent_enabled` if set to false then the agent will not be spawned and its lifecycle will be up to the user of the action. Useful when testing K8s like integrations
 - `region` is where to send the e2e data. Possible values: "US", "EU", "Staging", "Local". See `action.yaml` for more info.
+- `scenario_tag` is used as an environment variable in the spec file under `spec_path`. For now, our nri-kubernetes repo uses it as namespace and cluster names. Customers can define this value as their cluster name if they do not want to use random cluster name during the testing.
 
 ## Spec file for the e2e
 

--- a/internal/runtime/runner.go
+++ b/internal/runtime/runner.go
@@ -34,6 +34,7 @@ type Runner struct {
 	retryAttempts int
 	retryAfter    time.Duration
 	commitSha     string
+	scenarioTag   string
 }
 
 func NewRunner(testers []Tester, settings e2e.Settings) *Runner {
@@ -63,6 +64,7 @@ func NewRunner(testers []Tester, settings e2e.Settings) *Runner {
 		retryAttempts: retryAttempts,
 		retryAfter:    retryAfter,
 		commitSha:     settings.CommitSha(),
+		scenarioTag:   settings.ScenarioTag(),
 	}
 }
 
@@ -148,6 +150,11 @@ func (r *Runner) executeTests(tests spec.Tests, customTestKey string, scenarioTa
 }
 
 func (r *Runner) generateScenarioTag() string {
+	// if there is a customer defined scenario tag, just return it instead of generating a randome one.
+	if len(r.scenarioTag) > 0 {
+		return r.scenarioTag
+	}
+
 	b := make([]rune, scenarioTagRuneNr)
 	for i := range b {
 		b[i] = letterRunes[rand.Intn(len(letterRunes))]

--- a/internal/settings.go
+++ b/internal/settings.go
@@ -24,6 +24,7 @@ type settingOptions struct {
 	retrySeconds  int
 	commitSha     string
 	region        string
+	scenarioTag   string
 }
 
 type SettingOption func(*settingOptions)
@@ -89,6 +90,12 @@ func SettingsWithRegion(region string) SettingOption {
 	}
 }
 
+func SettingsWithScenarioTag(scenarioTag string) SettingOption {
+	return func(o *settingOptions) {
+		o.scenarioTag = scenarioTag
+	}
+}
+
 type Settings interface {
 	Logger() *logrus.Logger
 	SpecDefinition() *spec.Definition
@@ -102,6 +109,7 @@ type Settings interface {
 	RetrySeconds() int
 	CommitSha() string
 	Region() string
+	ScenarioTag() string
 }
 
 type settings struct {
@@ -116,6 +124,7 @@ type settings struct {
 	retrySeconds   int
 	commitSha      string
 	region         string
+	scenarioTag    string
 }
 
 func (s *settings) Logger() *logrus.Logger {
@@ -173,6 +182,10 @@ func (s *settings) Region() string {
 	return "US"
 }
 
+func (s *settings) ScenarioTag() string {
+	return s.scenarioTag
+}
+
 // New returns a Scheduler
 func NewSettings(
 	opts ...SettingOption) (Settings, error) {
@@ -205,5 +218,6 @@ func NewSettings(
 		retrySeconds:   options.retrySeconds,
 		commitSha:      options.commitSha,
 		region:         options.region,
+		scenarioTag:    options.scenarioTag,
 	}, nil
 }

--- a/main.go
+++ b/main.go
@@ -35,7 +35,7 @@ func processCliArgs() (string, string, bool, string, int, int, int, string, logr
 	retrySeconds := flag.Int(flagRetrySecons, 60, "Number of seconds before retrying a test")
 	commitSha := flag.String(flagCommitSha, "", "Current commit sha")
 	region := flag.String(flagRegion, "", "Current commit sha")
-	scenarioTag := flag.String(flagScenarioTag, "", "E2e testing scenario")
+	scenarioTag := flag.String(flagScenarioTag, "", "E2e testing scenario tag")
 	flag.Parse()
 
 	if *licenseKey == "" {

--- a/main.go
+++ b/main.go
@@ -21,9 +21,10 @@ const (
 	flagRetrySecons   = "retry_seconds"
 	flagCommitSha     = "commit_sha"
 	flagRegion        = "region"
+	flagScenarioTag   = "scenario_tag"
 )
 
-func processCliArgs() (string, string, bool, string, int, int, int, string, logrus.Level, string) {
+func processCliArgs() (string, string, bool, string, int, int, int, string, logrus.Level, string, string) {
 	specsPath := flag.String(flagSpecPath, "", "Path to the spec file")
 	licenseKey := flag.String(flagLicenseKey, "", "New Relic License Key")
 	agentEnabled := flag.Bool(flagAgentEnabled, true, "If false the agent is not run")
@@ -34,6 +35,7 @@ func processCliArgs() (string, string, bool, string, int, int, int, string, logr
 	retrySeconds := flag.Int(flagRetrySecons, 60, "Number of seconds before retrying a test")
 	commitSha := flag.String(flagCommitSha, "", "Current commit sha")
 	region := flag.String(flagRegion, "", "Current commit sha")
+	scenarioTag := flag.String(flagScenarioTag, "", "E2e testing scenario")
 	flag.Parse()
 
 	if *licenseKey == "" {
@@ -53,13 +55,13 @@ func processCliArgs() (string, string, bool, string, int, int, int, string, logr
 	if *verboseMode {
 		logLevel = logrus.DebugLevel
 	}
-	return *licenseKey, *specsPath, *agentEnabled, *apiKey, *accountID, *retryAttempts, *retrySeconds, *commitSha, logLevel, *region
+	return *licenseKey, *specsPath, *agentEnabled, *apiKey, *accountID, *retryAttempts, *retrySeconds, *commitSha, logLevel, *region, *scenarioTag
 }
 
 func main() {
 	logrus.Info("running e2e")
 
-	licenseKey, specsPath, agentEnabled, apiKey, accountID, retryAttempts, retrySeconds, commitSha, logLevel, region := processCliArgs()
+	licenseKey, specsPath, agentEnabled, apiKey, accountID, retryAttempts, retrySeconds, commitSha, logLevel, region, scenarioTag := processCliArgs()
 	s, err := e2e.NewSettings(
 		e2e.SettingsWithSpecPath(specsPath),
 		e2e.SettingsWithLogLevel(logLevel),
@@ -71,6 +73,7 @@ func main() {
 		e2e.SettingsWithRetrySeconds(retrySeconds),
 		e2e.SettingsWithCommitSha(commitSha),
 		e2e.SettingsWithRegion(region),
+		e2e.SettingsWithScenarioTag(scenarioTag),
 	)
 	if err != nil {
 		logrus.Fatalf("error loading settings: %s", err)


### PR DESCRIPTION
# Description
AWS is working on a conformance testing framework for EKS-Anywhere, which helps partners to get their products plugged in and test automatically against (a) All existing and new supported hardware for EKS-A (b) All existing and new versions of EKS version updates on EKS-Anywhere. This framework eliminates complexities that partners go through to procure new hardware (which many times may not be doable) to validate their products on EKS-A and helps AWS release with confidence and including partners in any upcoming launches (without any additional efforts from partners' end)

The framework is open sourced and an EKS engineer is making the necessary changes to plug in NEWR helm chart installation to this framework. To make the New Relic Testing fully automated, we need to open the ScenarioTag environment variable configurable to users of the e2e action.

# Code Change
I open the ScenarioTag env and make it configurable to users of the e2e action.
