### PR TITLE
Add expected nrql responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,8 +124,8 @@ The spec file for the e2e needs to be a yaml file with the following structure:
   - `config` : The config values for this NR integration that will be red by the agent to execute the integration.
 - `tests` : The 3 kinds of tests that will be done to the New relic api to check for metrics/entities in NROne:
   - `nrqls` : Array of queries that will be executed independently. You can specify if running a query an error is expected or not.
-  - `query` : the query to run
-  - `error_expected`: false by default, useful if we want to test that a metric is not being sent
+    - `query` : the query to run
+    - `error_expected`: false by default, useful if we want to test that a metric is not being sent
   - `metrics` : Array of metrics to check existing in NROne
     - `source` : Relative path to the integration spec file (It defines the entities and metrics) that will be parsed to match the metrics got from NROne.
     - `except_entities` : Array of entities whose metrics will be skipped.

--- a/internal/newrelic/client.go
+++ b/internal/newrelic/client.go
@@ -121,11 +121,14 @@ func (nrc *nrClient) NRQLQuery(query, customTagKey, entityTag string, errorExpec
 		}
 		return nil
 	} else {
-		//FIXME
-		expectedResult := expectedResults[0]
-		stringResult := fmt.Sprintf("%v", a.Results[0][expectedResult.Key])
-		if stringResult != expectedResult.Value {
-			return fmt.Errorf("%w: %s - expected for key '%s': '%s' got '%s'", errors.New("query did not return expected value"), query, expectedResult.Key, expectedResult.Value, stringResult)
+		if len(expectedResults) != len(a.Results) {
+			return fmt.Errorf("%w: %s - expected %d got %d", errors.New("query did not return expected number of results"), len(expectedResults), len(a.Results))
+		}
+		for i, expectedResult := range expectedResults {
+			stringResult := fmt.Sprintf("%v", a.Results[i][expectedResult.Key])
+			if stringResult != expectedResult.Value {
+				return fmt.Errorf("%w: %s - expected for key '%s': '%s' got '%s'", errors.New("query did not return expected results"), query, expectedResult.Key, expectedResult.Value, stringResult)
+			}
 		}
 		return nil
 	}

--- a/internal/runtime/nr_client_mock_test.go
+++ b/internal/runtime/nr_client_mock_test.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"errors"
+	"github.com/newrelic/newrelic-integration-e2e-action/internal/spec"
 
 	"github.com/newrelic/newrelic-client-go/pkg/common"
 	"github.com/newrelic/newrelic-client-go/pkg/entities"
@@ -40,8 +41,12 @@ func (c clientMock) FindEntityMetrics(sample, customTagKey, entityTag string) ([
 	return []string{"powerdns_authoritative_deferred_cache_actions"}, nil
 }
 
-func (c clientMock) NRQLQuery(query, customTagKey, entityTag string) error {
-	if query == errNRQLQuery {
+func (c clientMock) NRQLQuery(query, customTagKey, entityTag string, errorExpected bool, expectedResults []spec.TestNRQLExpectedResult) error {
+
+	if query == errNRQLQuery && !errorExpected {
+		return errors.New("an-error")
+	}
+	if query != errNRQLQuery && errorExpected {
 		return errors.New("an-error")
 	}
 	return nil

--- a/internal/runtime/nrql_tester.go
+++ b/internal/runtime/nrql_tester.go
@@ -3,7 +3,6 @@ package runtime
 import (
 	"errors"
 	"fmt"
-
 	"github.com/newrelic/newrelic-integration-e2e-action/internal/newrelic"
 	"github.com/newrelic/newrelic-integration-e2e-action/internal/spec"
 	"github.com/sirupsen/logrus"
@@ -26,14 +25,9 @@ var ErrorExpected = errors.New("an error was expected")
 func (nt NRQLTester) Test(tests spec.Tests, customTagKey, customTagValue string) []error {
 	var errors []error
 	for _, nrql := range tests.NRQLs {
-		err := nt.nrClient.NRQLQuery(nrql.Query, customTagKey, customTagValue)
-		if err != nil && !nrql.ErrorExpected {
-			errors = append(errors, fmt.Errorf("querying: %w", err))
-			continue
-		}
-		if err == nil && nrql.ErrorExpected {
-			errors = append(errors, fmt.Errorf("running %q: %w", nrql.Query, ErrorExpected))
-			continue
+		err := nt.nrClient.NRQLQuery(nrql.Query, customTagKey, customTagValue, nrql.ErrorExpected, nrql.ExpectedResults)
+		if err != nil {
+			errors = append(errors, fmt.Errorf(err.Error()))
 		}
 	}
 	return errors

--- a/internal/runtime/runner.go
+++ b/internal/runtime/runner.go
@@ -4,6 +4,7 @@ import (
 	"math/rand"
 	"os"
 	"os/exec"
+	"strings"
 	"time"
 
 	e2e "github.com/newrelic/newrelic-integration-e2e-action/internal"
@@ -71,7 +72,7 @@ func NewRunner(testers []Tester, settings e2e.Settings) *Runner {
 func (r *Runner) Run() error {
 	for _, scenario := range r.spec.Scenarios {
 		scenarioTag := r.generateScenarioTag()
-		r.logger.Debugf("[scenario]: %s, [Tag]: %s", scenario.Description, scenarioTag)
+		r.logger.Debugf("[scenario]: %s, [Tag]: %s", strings.TrimSpace(scenario.Description), scenarioTag)
 
 		if err := r.executeOSCommands(scenario.Before, scenarioTag); err != nil {
 			return err

--- a/internal/spec/definition.go
+++ b/internal/spec/definition.go
@@ -41,8 +41,14 @@ type Tests struct {
 }
 
 type TestNRQL struct {
-	Query         string `yaml:"query"`
-	ErrorExpected bool   `yaml:"error_expected"`
+	Query           string                   `yaml:"query"`
+	ErrorExpected   bool                     `yaml:"error_expected"`
+	ExpectedResults []TestNRQLExpectedResult `yaml:"expected_results"`
+}
+
+type TestNRQLExpectedResult struct {
+	Key   string `yaml:"key"`
+	Value string `yaml:"value"`
 }
 
 type TestEntity struct {


### PR DESCRIPTION
- Adds support for asserting the response value of NRQL tests
  - Supports single and multiple expected values (such as in timeseries and facet queries)