### PR TITLE
Use the same secrets for e2e than the org

### DIFF
--- a/.github/workflows/push-code.yml
+++ b/.github/workflows/push-code.yml
@@ -17,10 +17,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: newrelic/newrelic-infra-checkers@v1
-      - name: Semgrep
-        uses: returntocorp/semgrep-action@v1
-        with:
-          auditOn: push
       - uses: actions/setup-go@v3
         with:
           go-version-file: go.mod

--- a/.github/workflows/selftest.yml
+++ b/.github/workflows/selftest.yml
@@ -24,9 +24,9 @@ jobs:
         uses: ./
         with:
           spec_path: test/testdata/powerdns/powerdns-e2e.yml
-          account_id: ${{ secrets.ACCOUNT_ID }}
-          api_key: ${{ secrets.API_KEY }}
-          license_key: ${{ secrets.LICENSE_KEY }}
+          account_id: ${{ secrets.COREINT_E2E_ACCOUNT_ID }}
+          api_key: ${{ secrets.COREINT_E2E_API_KEY }}
+          license_key: ${{ secrets.COREINT_E2E_LICENSE_KEY }}
   test_local_kafka:
     runs-on: ubuntu-latest
     name: Test run the e2e test on kafka local testdata
@@ -39,9 +39,9 @@ jobs:
         uses: ./
         with:
           spec_path: test/testdata/kafka/kafka-e2e.yml
-          account_id: ${{ secrets.ACCOUNT_ID }}
-          api_key: ${{ secrets.API_KEY }}
-          license_key: ${{ secrets.LICENSE_KEY }}
+          account_id: ${{ secrets.COREINT_E2E_ACCOUNT_ID }}
+          api_key: ${{ secrets.COREINT_E2E_API_KEY }}
+          license_key: ${{ secrets.COREINT_E2E_LICENSE_KEY }}
   test_local_k8s:
     # To be able to use driver=none we have to provide a CRI that kubelet allows.
     # Or we do the research to use `ubuntu-latest` or we should keep to an old version of Ubuntu and Kubernetes
@@ -70,7 +70,7 @@ jobs:
         uses: ./
         with:
           spec_path: test/testdata/k8s/k8s-e2e.yml
-          account_id: ${{ secrets.ACCOUNT_ID }}
-          api_key: ${{ secrets.API_KEY }}
-          license_key: ${{ secrets.LICENSE_KEY }}
+          account_id: ${{ secrets.COREINT_E2E_ACCOUNT_ID }}
+          api_key: ${{ secrets.COREINT_E2E_API_KEY }}
+          license_key: ${{ secrets.COREINT_E2E_LICENSE_KEY }}
           agent_enabled: "false"


### PR DESCRIPTION
This eases the secret rotation by using the same secrets we use to test the OHAIs.

As the action is not touched, there is no need to release/bump the version.