### PR TITLE
fix: wrap path variables in quotes to prevent character escaping in windows-style paths

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -49,5 +49,5 @@ runs:
   using: "composite"
   steps:
     - id: run-spec
-      run: make -C ${{ github.action_path }} COMMIT_SHA=${{ github.sha }} AGENT_ENABLED=${{ inputs.agent_enabled }} ROOT_DIR=${{ github.workspace }} ACCOUNT_ID=${{ inputs.account_id }} API_KEY=${{ inputs.api_key }} LICENSE_KEY=${{ inputs.license_key }} SPEC_PATH=${{ inputs.spec_path }} RETRY_ATTEMPTS=${{ inputs.retry_attempts }} RETRY_SECONDS=${{ inputs.retry_seconds }} VERBOSE=${{ inputs.verbose }} REGION=${{ inputs.region }} SCENARIO_TAG=${{ inputs.scenario_tag }} run
+      run: make -C "${{ github.action_path }}" COMMIT_SHA=${{ github.sha }} AGENT_ENABLED=${{ inputs.agent_enabled }} ROOT_DIR="${{ github.workspace }}" ACCOUNT_ID=${{ inputs.account_id }} API_KEY=${{ inputs.api_key }} LICENSE_KEY=${{ inputs.license_key }} SPEC_PATH=${{ inputs.spec_path }} RETRY_ATTEMPTS=${{ inputs.retry_attempts }} RETRY_SECONDS=${{ inputs.retry_seconds }} VERBOSE=${{ inputs.verbose }} REGION=${{ inputs.region }} SCENARIO_TAG=${{ inputs.scenario_tag }} run
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -49,5 +49,5 @@ runs:
   using: "composite"
   steps:
     - id: run-spec
-      run: make -C "${{ github.action_path }}" COMMIT_SHA=${{ github.sha }} AGENT_ENABLED=${{ inputs.agent_enabled }} ROOT_DIR="${{ github.workspace }}" ACCOUNT_ID=${{ inputs.account_id }} API_KEY=${{ inputs.api_key }} LICENSE_KEY=${{ inputs.license_key }} SPEC_PATH=${{ inputs.spec_path }} RETRY_ATTEMPTS=${{ inputs.retry_attempts }} RETRY_SECONDS=${{ inputs.retry_seconds }} VERBOSE=${{ inputs.verbose }} REGION=${{ inputs.region }} SCENARIO_TAG=${{ inputs.scenario_tag }} run
+      run: make -C "${{ github.action_path }}" COMMIT_SHA=${{ github.sha }} AGENT_ENABLED=${{ inputs.agent_enabled }} ROOT_DIR="${{ github.workspace }}" ACCOUNT_ID=${{ inputs.account_id }} API_KEY=${{ inputs.api_key }} LICENSE_KEY=${{ inputs.license_key }} SPEC_PATH="${{ inputs.spec_path }}" RETRY_ATTEMPTS=${{ inputs.retry_attempts }} RETRY_SECONDS=${{ inputs.retry_seconds }} VERBOSE=${{ inputs.verbose }} REGION=${{ inputs.region }} SCENARIO_TAG=${{ inputs.scenario_tag }} run
       shell: bash


### PR DESCRIPTION
### Summary

When this action is run on a Windows GitHub runner, paths can contain backslashes which are treated as escape characters in bash. The resulting behavior is that a path like `D:\a\_action\newrelic\newrelic-integration-e2e-action` becomes `D:a_actionsnewrelicnewrelic-integration-e2e-action`, resulting in directory-not-found errors

This PR wraps the `${{ github.action_path }}`, `${{ github.workspace }}`, and `${{ inputs.spec_path }}` expressions in quotes to prevent the shell from interpreting backslashes as escape characters.